### PR TITLE
Add error implementation for `ValidRejection`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod typed_header;
 #[cfg(feature = "yaml")]
 pub mod yaml;
 
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
 use axum::async_trait;
 use axum::extract::{FromRequest, FromRequestParts};
 use axum::http::request::Parts;
@@ -54,12 +56,24 @@ impl<E> DerefMut for Valid<E> {
 
 /// If the valid extractor fails it'll use this "rejection" type.
 /// This rejection type can be converted into a response.
+#[derive(Debug)]
 pub enum ValidRejection<E> {
     /// Validation errors
     Valid(ValidationErrors),
     /// Inner extractor error
     Inner(E),
 }
+
+impl<E: Display> Display for ValidRejection<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidRejection::Valid(errors) => write!(f, "{errors}"),
+            ValidRejection::Inner(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl<E: Debug + Display> Error for ValidRejection<E> {}
 
 impl<E> From<ValidationErrors> for ValidRejection<E> {
     fn from(value: ValidationErrors) -> Self {


### PR DESCRIPTION
Hello!

I'm currently working on a `Catch` type that transforms the `Rejection` of any `FromRequest` type into any other type using the `From` trait, allowing users to do something like this:

```rust
async fn bar(Catch(Json(foo), _): Catch<Json<Foo>, MyJsonError>) -> impl IntoResponse {
     // ...
}
```

My main motivation for this type is to make any parameter return JSON on error, by converting it to a project-specific error type. This solves the problem of JSON endpoints returning non-JSON when something goes wrong, and can also be used to make robust endpoints for other types of output (human-readable, yaml, etc.).

However, when I try to use this type in conjunction with the `Valid` parameter:

```rust
async fn bar(Catch(Valid(Json(foo)), _): Catch<Valid<Json<Foo>>, MyJsonError>) -> impl IntoResponse {
     // ...
}
```

I get a compile-time error, because I cannot convert a `ValidRejection<T>` into my own error type in a meaningful way (without losing the information as to what went wrong). Implementing `Debug`, `Display`, and `Error` for `ValidRejection` would solve this problem, hence this PR.

I know the `ValidRejection` type already has the option to format its output as JSON, which is great! However, the `Catch` type can support other types of output, and support all of them within one binary (for instance, returning human-readable format in one handler and JSON in another), so I still think this can be a good addition!