### PR TITLE
update validator crate 0.17.0 -> 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = ["full", "aide"]
 [dependencies]
 axum = { version = "0.7.3", default-features = false }
 garde = { version = "0.18.0", optional = true }
-validator = { version = "0.17.0", optional = true }
+validator = { version = "0.18.0", optional = true }
 validify = { version = "1.3.0", optional = true }
 
 [dependencies.axum-extra]
@@ -57,7 +57,7 @@ axum = { version = "0.7.1", features = ["macros"] }
 tokio = { version = "1.34.0", features = ["full"] }
 reqwest = { version = "0.11.23", features = ["json", "multipart"] }
 serde = { version = "1.0.195", features = ["derive"] }
-validator = { version = "0.17.0", features = ["derive"] }
+validator = { version = "0.18.0", features = ["derive"] }
 garde = { version = "0.18.0", features = ["serde", "derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -252,8 +252,8 @@ pub mod tests {
         assert_eq!(&inner, v.deref());
         assert_eq!(inner, v.into_inner());
 
-        fn validate(v: &i32, args: &DataVA) -> Result<(), ValidationError> {
-            assert!(*v < args.a);
+        fn validate(v: i32, args: &DataVA) -> Result<(), ValidationError> {
+            assert!(v < args.a);
             Ok(())
         }
 

--- a/src/validator/test.rs
+++ b/src/validator/test.rs
@@ -47,10 +47,10 @@ pub struct ParametersEx {
     v1: String,
 }
 
-fn validate_v0(v: &i32, args: &ParametersExValidationArguments) -> Result<(), ValidationError> {
+fn validate_v0(v: i32, args: &ParametersExValidationArguments) -> Result<(), ValidationError> {
     args.inner
         .v0_range
-        .contains(v)
+        .contains(&v)
         .then_some(())
         .ok_or_else(|| ValidationError::new("v0 is out of range"))
 }
@@ -1208,11 +1208,11 @@ mod extra_typed_path {
     }
 
     fn validate_v0(
-        v: &i32,
+        v: i32,
         args: &TypedPathParamExValidationArguments,
     ) -> Result<(), ValidationError> {
         args.v0_range
-            .contains(v)
+            .contains(&v)
             .then_some(())
             .ok_or_else(|| ValidationError::new("v0 is out of range"))
     }


### PR DESCRIPTION
I updated the `validator` crate. There were no major changes. It seems that if the field to validate is `Integer Types`, it now receives a copy instead of a reference.

closes #22