### PR TITLE
Upgrade validator to 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ features = ["full", "aide"]
 [dependencies]
 axum = { version = "0.7.5", default-features = false }
 garde = { version = "0.20.0", optional = true }
-validator = { version = "0.18.1", optional = true }
+validator = { version = "0.19.0", optional = true }
 validify = { version = "1.4.0", optional = true }
 
 [dependencies.axum-extra]
@@ -57,7 +57,7 @@ axum = { version = "0.7.5", features = ["macros"] }
 tokio = { version = "1.34.0", features = ["full"] }
 reqwest = { version = "0.12.3", features = ["json", "multipart"] }
 serde = { version = "1.0.195", features = ["derive"] }
-validator = { version = "0.18.0", features = ["derive"] }
+validator = { version = "0.19.0", features = ["derive"] }
 garde = { version = "0.20.0", features = ["serde", "derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"


### PR DESCRIPTION
While trying to use package-provided validators and a few custom validators of my own, I've run into this error:

```
thread '<...>' panicked at <home>/.cargo/registry/src/index.crates.io-6f17d22bba15001f/validator-0.18.1/src/types.rs:185:13:
Attempt to replace non-empty ValidationErrors entry
```

This PR upgrades `validator` to `0.19.0` to get the corresponding fix for validating struct with multiple members, which was reported in https://github.com/Keats/validator/issues/319 and fixed in https://github.com/Keats/validator/pull/321.