### PR TITLE
axum 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ edition = "2021"
 features = ["full", "aide"]
 
 [dependencies]
-axum = { version = "0.7.5", default-features = false }
-garde = { version = "0.20.0", optional = true }
+axum = { version = "0.8", default-features = false }
+garde = { version = "0.21.0", optional = true }
 validator = { version = "0.19.0", optional = true }
 validify = { version = "1.4.0", optional = true }
 
 [dependencies.axum-extra]
-version = "0.9.3"
+version = "0.10"
 default-features = false
 optional = true
 
@@ -40,7 +40,7 @@ version = "0.7.0"
 optional = true
 
 [dependencies.axum_typed_multipart]
-version = "0.13.1"
+version = "0.14"
 optional = true
 
 [dependencies.serde]
@@ -53,12 +53,12 @@ optional = true
 
 [dev-dependencies]
 anyhow = "1.0.87"
-axum = { version = "0.7.5", features = ["macros"] }
+axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1.34.0", features = ["full"] }
 reqwest = { version = "0.12.3", features = ["json", "multipart"] }
 serde = { version = "1.0.195", features = ["derive"] }
 validator = { version = "0.19.0", features = ["derive"] }
-garde = { version = "0.20.0", features = ["serde", "derive"] }
+garde = { version = "0.21.0", features = ["serde", "derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
 quick-xml = { version = "0.36.1", features = ["serialize"] }

--- a/src/garde.rs
+++ b/src/garde.rs
@@ -9,7 +9,6 @@
 pub mod test;
 
 use crate::{HasValidate, ValidationRejection};
-use axum::async_trait;
 use axum::extract::{FromRef, FromRequest, FromRequestParts, Request};
 use axum::http::request::Parts;
 use garde::{Report, Validate};
@@ -77,7 +76,6 @@ impl<E> From<Report> for GardeRejection<E> {
     }
 }
 
-#[async_trait]
 impl<State, Extractor, Context> FromRequest<State> for Garde<Extractor>
 where
     State: Send + Sync,
@@ -98,7 +96,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor, Context> FromRequestParts<State> for Garde<Extractor>
 where
     State: Send + Sync,

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -9,7 +9,6 @@
 pub mod test;
 
 use crate::{HasValidate, ValidationRejection};
-use axum::async_trait;
 use axum::extract::{FromRef, FromRequest, FromRequestParts, Request};
 use axum::http::request::Parts;
 use std::fmt::Display;
@@ -144,7 +143,6 @@ pub trait HasValidateArgs<'v> {
     fn get_validate_args(&self) -> &Self::ValidateArgs;
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequest<State> for Valid<Extractor>
 where
     State: Send + Sync,
@@ -162,7 +160,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequestParts<State> for Valid<Extractor>
 where
     State: Send + Sync,
@@ -180,7 +177,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor, Args> FromRequest<State> for ValidEx<Extractor>
 where
     State: Send + Sync,
@@ -201,7 +197,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor, Args> FromRequestParts<State> for ValidEx<Extractor>
 where
     State: Send + Sync,

--- a/src/validify.rs
+++ b/src/validify.rs
@@ -9,7 +9,6 @@
 pub mod test;
 
 use crate::{HasValidate, ValidationRejection};
-use axum::async_trait;
 use axum::extract::{FromRequest, FromRequestParts, Request};
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
@@ -301,7 +300,6 @@ pub trait HasValidify: Sized {
     fn from_validify(v: Self::Validify) -> Self;
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequest<State> for Validated<Extractor>
 where
     State: Send + Sync,
@@ -319,7 +317,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequestParts<State> for Validated<Extractor>
 where
     State: Send + Sync,
@@ -337,7 +334,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequest<State> for Modified<Extractor>
 where
     State: Send + Sync,
@@ -352,7 +348,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequestParts<State> for Modified<Extractor>
 where
     State: Send + Sync,
@@ -367,7 +362,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequest<State> for Validified<Extractor>
 where
     State: Send + Sync,
@@ -387,7 +381,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequestParts<State> for Validified<Extractor>
 where
     State: Send + Sync,
@@ -407,7 +400,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequest<State> for ValidifiedByRef<Extractor>
 where
     State: Send + Sync,
@@ -426,7 +418,6 @@ where
     }
 }
 
-#[async_trait]
 impl<State, Extractor> FromRequestParts<State> for ValidifiedByRef<Extractor>
 where
     State: Send + Sync,


### PR DESCRIPTION
upgrade axum to version `0.8`.
remove the `#[async_trait]` (its removed from the axum in 0.8 and its no longer needed)