### PR TITLE
Bump aide version to 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ version = "1.0.217"
 optional = true
 
 [dependencies.aide]
-version = "0.14.0"
+version = "0.15.0"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
This pull request bumps aide version to 0.15.0 to allow usage with the latest version.

It has been tested, it compiled successfully and validations work.